### PR TITLE
Task1 ux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@
 - Prefer short, single-line commit messages by default.
 - Add a commit body only when explaining non-obvious decisions or performance tradeoffs.
 - Do not include AI attribution footers (e.g., Co-Authored-By) unless I explicitly ask. This is to keep commits clean - AI Attribution will be added in a deliverable document/README.
+- Make sure to show the proposed commit message and wait for explicit approval before running the git commit command.
 
 
 ## Optimize for:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup test test-unit test-integration test-watch clean start stop logs
+.PHONY: help setup test test-unit test-integration test-watch clean start stop logs rebuild-frontend
 
 # Default target
 help:
@@ -11,6 +11,7 @@ help:
 	@echo "  make start              - Start all services (dev environment)"
 	@echo "  make stop               - Stop all services"
 	@echo "  make logs               - Show logs for all services"
+	@echo "  make rebuild-frontend   - Rebuild and restart frontend service"
 	@echo "  make clean              - Stop services and clean up volumes"
 
 # Initial setup
@@ -53,6 +54,13 @@ stop:
 
 logs:
 	@docker compose logs -f
+
+# Rebuild frontend
+rebuild-frontend:
+	@echo "Rebuilding frontend..."
+	@docker compose build frontend
+	@docker compose up -d frontend
+	@echo "Frontend rebuilt and restarted!"
 
 # Clean up
 clean:

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -138,7 +138,7 @@ function QualityDashboard() {
 
         <div className="mb-6">
           <ResponsiveContainer width="100%" height={450}>
-            <BarChart data={chartData} margin={{ top: 30, right: 10, left: 80, bottom: 0 }}>
+            <BarChart data={chartData} margin={{ top: 30, right: 10, left: 30, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" opacity={0.5} />
               <XAxis
                 dataKey="name"

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -155,7 +155,7 @@ function QualityDashboard() {
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Study
                   </th>
-                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-400 uppercase tracking-wider">
                     Total Measurements
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -178,7 +178,7 @@ function QualityDashboard() {
                         <div className="text-sm text-gray-500">{item.study_id}</div>
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900 tabular-nums">
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-500 tabular-nums">
                       {item.total_measurements.toLocaleString()}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -104,11 +104,20 @@ function QualityDashboard() {
         <div className="mb-6">
           <ResponsiveContainer width="100%" height={400}>
             <BarChart data={chartData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" angle={-45} textAnchor="end" height={120} />
-              <YAxis />
-              <Tooltip />
-              <Legend />
+              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" opacity={0.5} />
+              <XAxis
+                dataKey="name"
+                angle={-45}
+                textAnchor="end"
+                height={120}
+                tick={{ fontSize: 14, fill: '#1f2937' }}
+              />
+              <YAxis
+                tick={{ fontSize: 14, fill: '#1f2937' }}
+                label={{ value: 'Count', angle: -90, position: 'insideLeft', style: { fontSize: 14, fill: '#1f2937' } }}
+              />
+              <Tooltip contentStyle={{ fontSize: 14 }} />
+              <Legend wrapperStyle={{ fontSize: 14 }} />
               <Bar dataKey="High Quality (≥0.9)" fill="#10b981" />
               <Bar dataKey="Low Quality (<0.8)" fill="#ef4444" />
             </BarChart>
@@ -147,11 +156,11 @@ function QualityDashboard() {
                         <div className="text-sm text-gray-500">{item.study_id}</div>
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900">
                       {item.total_measurements.toLocaleString()}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">
-                      <span className={`inline-flex text-sm font-medium ${
+                      <span className={`inline-flex text-base font-semibold ${
                         parseFloat(item.avg_quality_score.toString()) >= 0.9
                           ? 'text-green-600'
                           : parseFloat(item.avg_quality_score.toString()) >= 0.8
@@ -161,10 +170,10 @@ function QualityDashboard() {
                         {parseFloat(item.avg_quality_score.toString()).toFixed(3)}
                       </span>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900">
                       {item.high_quality_count.toLocaleString()}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900">
                       {item.low_quality_count.toLocaleString()}
                     </td>
                   </tr>

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -178,11 +178,11 @@ function QualityDashboard() {
                         <div className="text-sm text-gray-500">{item.study_id}</div>
                       </div>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900 tabular-nums">
                       {item.total_measurements.toLocaleString()}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">
-                      <span className={`inline-flex text-base font-semibold ${
+                      <span className={`inline-flex text-base font-semibold tabular-nums ${
                         parseFloat(item.avg_quality_score.toString()) >= 0.9
                           ? 'text-green-600'
                           : parseFloat(item.avg_quality_score.toString()) >= 0.8
@@ -192,10 +192,10 @@ function QualityDashboard() {
                         {parseFloat(item.avg_quality_score.toString()).toFixed(3)}
                       </span>
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900 tabular-nums">
                       {item.high_quality_count.toLocaleString()}
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900">
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900 tabular-nums">
                       {item.low_quality_count.toLocaleString()}
                     </td>
                   </tr>

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -1,11 +1,19 @@
 import { useState, useEffect } from 'react';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
 import type { QualityDistributionResponse } from '../types';
 
 function QualityDashboard() {
   const [data, setData] = useState<QualityDistributionResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Format numbers with k suffix for thousands
+  const formatNumber = (value: number): string => {
+    if (value >= 1000) {
+      return (value / 1000).toFixed(1) + 'k';
+    }
+    return value.toString();
+  };
 
   const fetchQualityData = async () => {
     setLoading(true);
@@ -102,8 +110,8 @@ function QualityDashboard() {
         </div>
 
         <div className="mb-6">
-          <ResponsiveContainer width="100%" height={400}>
-            <BarChart data={chartData}>
+          <ResponsiveContainer width="100%" height={450}>
+            <BarChart data={chartData} margin={{ top: 30, right: 10, left: 10, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" opacity={0.5} />
               <XAxis
                 dataKey="name"
@@ -118,8 +126,22 @@ function QualityDashboard() {
               />
               <Tooltip contentStyle={{ fontSize: 14 }} />
               <Legend wrapperStyle={{ fontSize: 14 }} />
-              <Bar dataKey="High Quality (≥0.9)" fill="#10b981" />
-              <Bar dataKey="Low Quality (<0.8)" fill="#ef4444" />
+              <Bar dataKey="High Quality (≥0.9)" fill="#10b981">
+                <LabelList
+                  dataKey="High Quality (≥0.9)"
+                  position="top"
+                  formatter={formatNumber}
+                  style={{ fontSize: 12, fontWeight: 600, fill: '#1f2937' }}
+                />
+              </Bar>
+              <Bar dataKey="Low Quality (<0.8)" fill="#ef4444">
+                <LabelList
+                  dataKey="Low Quality (<0.8)"
+                  position="top"
+                  formatter={formatNumber}
+                  style={{ fontSize: 12, fontWeight: 600, fill: '#1f2937' }}
+                />
+              </Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -189,7 +189,7 @@ function QualityDashboard() {
                           ? 'text-yellow-600'
                           : 'text-red-600'
                       }`}>
-                        {parseFloat(item.avg_quality_score.toString()).toFixed(3)}
+                        {parseFloat(item.avg_quality_score.toString()).toFixed(4)}
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900 tabular-nums">

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -115,9 +115,9 @@ function QualityDashboard() {
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" opacity={0.5} />
               <XAxis
                 dataKey="name"
-                angle={-45}
+                angle={-15}
                 textAnchor="end"
-                height={120}
+                height={80}
                 tick={{ fontSize: 14, fill: '#1f2937' }}
               />
               <YAxis

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -159,7 +159,18 @@ function QualityDashboard() {
                     Total Measurements
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Avg Quality
+                    <span className="inline-flex items-center gap-1">
+                      Avg Quality
+                      <span
+                        className="inline-block cursor-help"
+                        title="Average of record-level quality scores (0-1 scale)&#10;&#10;Green: ≥ 0.90 (High Quality)&#10;Yellow: ≥ 0.80 (Medium Quality)&#10;Red: < 0.80 (Low Quality)&#10;&#10;Note: Demo data generated during seeding"
+                        aria-label="Average quality score explanation: Scores range from 0 to 1, with green for high quality (0.90 or above), yellow for medium quality (0.80 to 0.89), and red for low quality (below 0.80). This is demo data."
+                      >
+                        <svg className="w-3.5 h-3.5 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                        </svg>
+                      </span>
+                    </span>
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                     High Quality

--- a/frontend/src/components/QualityDashboard.tsx
+++ b/frontend/src/components/QualityDashboard.tsx
@@ -7,12 +7,39 @@ function QualityDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Format numbers with k suffix for thousands
+  // Format numbers with k suffix for thousands (used in chart labels)
   const formatNumber = (value: number): string => {
     if (value >= 1000) {
       return (value / 1000).toFixed(1) + 'k';
     }
     return value.toString();
+  };
+
+  // Format counts with commas (used in tooltips and table)
+  const formatCount = (value: number): string => {
+    return value.toLocaleString();
+  };
+
+  // Format quality score with 4 decimals (used in tooltips and table)
+  const formatQuality = (value: number): string => {
+    return value.toFixed(4);
+  };
+
+  // Custom tooltip that uses consistent formatting
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-3 border border-gray-300 rounded shadow-lg">
+          <p className="text-sm font-medium text-gray-900 mb-2">{label}</p>
+          {payload.map((entry: any, index: number) => (
+            <p key={index} className="text-sm" style={{ color: entry.color }}>
+              {entry.name}: {formatCount(entry.value)}
+            </p>
+          ))}
+        </div>
+      );
+    }
+    return null;
   };
 
   const fetchQualityData = async () => {
@@ -111,7 +138,7 @@ function QualityDashboard() {
 
         <div className="mb-6">
           <ResponsiveContainer width="100%" height={450}>
-            <BarChart data={chartData} margin={{ top: 30, right: 10, left: 10, bottom: 0 }}>
+            <BarChart data={chartData} margin={{ top: 30, right: 10, left: 80, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" opacity={0.5} />
               <XAxis
                 dataKey="name"
@@ -122,9 +149,9 @@ function QualityDashboard() {
               />
               <YAxis
                 tick={{ fontSize: 14, fill: '#1f2937' }}
-                label={{ value: 'Count', angle: -90, position: 'insideLeft', style: { fontSize: 14, fill: '#1f2937' } }}
+                label={{ value: 'Record count', angle: -90, position: 'left', style: { fontSize: 14, fill: '#1f2937' } }}
               />
-              <Tooltip contentStyle={{ fontSize: 14 }} />
+              <Tooltip content={<CustomTooltip />} />
               <Legend wrapperStyle={{ fontSize: 14 }} />
               <Bar dataKey="High Quality (≥0.9)" fill="#10b981">
                 <LabelList
@@ -144,6 +171,9 @@ function QualityDashboard() {
               </Bar>
             </BarChart>
           </ResponsiveContainer>
+          <p className="text-xs text-gray-500 text-center mt-2">
+            Note: Values from 0.80–0.89 are not included in Low Quality.
+          </p>
         </div>
 
         <div className="border-t border-gray-200 pt-6">
@@ -181,8 +211,8 @@ function QualityDashboard() {
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
-                {data.data.map((item) => (
-                  <tr key={item.study_id}>
+                {data.data.map((item, index) => (
+                  <tr key={item.study_id} className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div>
                         <div className="text-sm font-medium text-gray-900">{item.study_name}</div>
@@ -190,7 +220,7 @@ function QualityDashboard() {
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-gray-500 tabular-nums">
-                      {item.total_measurements.toLocaleString()}
+                      {formatCount(item.total_measurements)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">
                       <span className={`inline-flex text-base font-semibold tabular-nums ${
@@ -200,14 +230,14 @@ function QualityDashboard() {
                           ? 'text-yellow-600'
                           : 'text-red-600'
                       }`}>
-                        {parseFloat(item.avg_quality_score.toString()).toFixed(4)}
+                        {formatQuality(parseFloat(item.avg_quality_score.toString()))}
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900 tabular-nums">
-                      {item.high_quality_count.toLocaleString()}
+                      {formatCount(item.high_quality_count)}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right text-base font-medium text-gray-900 tabular-nums">
-                      {item.low_quality_count.toLocaleString()}
+                      {formatCount(item.low_quality_count)}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Changes

- Standardized number formatting using shared helpers:
  - Counts use comma-separated integers (e.g. `117,955`)
  - Quality scores use 4-decimal precision (e.g. `0.8934`)
- Updated chart tooltip to use the same formatters as the table
- Improved chart readability:
  - Fixed Y-axis label clipping and added “Record count” label
  - Added value labels above bars
  - Reduced label rotation for easier scanning
  - Added legend note clarifying that values from 0.80–0.89 are not included in Low Quality
- Improved table readability with subtle zebra striping and minor text emphasis
- Added tooltip to **AVG QUALITY** explaining calculation and thresholds

### Before
<img width="3024" height="2276" alt="assessment - before" src="https://github.com/user-attachments/assets/2609c212-3b03-4f44-b07b-8ab29c825db1" />

### After
<img width="3024" height="2424" alt="assessment - after" src="https://github.com/user-attachments/assets/ac884a46-80a3-4805-b5bb-4f4338bce1dc" />

<img width="399" height="165" alt="image" src="https://github.com/user-attachments/assets/120c8619-9b29-49f7-89f4-2700be25e9d1" />

