### PR TITLE
feat: add in-memory caching with node-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
-.PHONY: help setup test test-unit test-integration test-frontend test-watch clean start stop logs rebuild-frontend
+.PHONY: help setup test test-frontend test-watch clean start stop logs rebuild-frontend
 
 # Default target
 help:
 	@echo "Available commands:"
 	@echo "  make setup              - Initial setup (copy .env.example, install deps)"
 	@echo "  make test               - Run all tests (frontend + API)"
-	@echo "  make test-frontend      - Run frontend unit tests"
-	@echo "  make test-unit          - Run API unit tests"
-	@echo "  make test-integration   - Run API contract tests (mocked, no DB)"
-	@echo "  make test-watch         - Run unit tests in watch mode"
+	@echo "  make test-frontend      - Run frontend tests only"
+	@echo "  make test-watch         - Run API tests in watch mode"
 	@echo "  make start              - Start all services (dev environment)"
 	@echo "  make stop               - Stop all services"
 	@echo "  make logs               - Show logs for all services"
@@ -27,24 +25,15 @@ setup:
 test:
 	@echo "Running frontend tests..."
 	@cd frontend && npm test
-	@echo "Running API integration tests..."
-	@cd api && npm run test:integration
-
-# Unit tests (no DB required)
-test-unit:
+	@echo "Running API tests..."
 	@cd api && npm test
 
-# Integration tests (mocked, no DB required)
-test-integration:
-	@echo "Running API contract tests..."
-	@cd api && npm run test:integration
-
-# Frontend tests
+# Frontend tests only
 test-frontend:
 	@echo "Running frontend tests..."
 	@cd frontend && npm test
 
-# Watch mode for unit tests
+# Watch mode for API tests
 test-watch:
 	@cd api && npm run test:watch
 

--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/src', '<rootDir>/tests'],
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
-  testPathIgnorePatterns: ['/node_modules/', '\\.integration\\.test\\.ts$'],
+  testPathIgnorePatterns: ['/node_modules/'],
   collectCoverageFrom: [
     'src/**/*.ts',
     '!src/**/*.d.ts',

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "node-cache": "^5.1.2",
     "pg": "^8.11.3"
   },
   "devDependencies": {

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -1,0 +1,36 @@
+import NodeCache from 'node-cache';
+
+const DEFAULT_TTL = parseInt(process.env.CACHE_TTL_SECONDS || '3600', 10); // 1 hour default
+
+export const cache = new NodeCache({
+  stdTTL: DEFAULT_TTL,
+  checkperiod: 120, // Check for expired keys every 2 minutes
+});
+
+// Cache-aside helper with hit tracking for observability
+export async function cacheGet<T>(
+  key: string,
+  fetchFn: () => Promise<T>,
+  ttl: number = DEFAULT_TTL
+): Promise<{ data: T; cached: boolean }> {
+  const cached = cache.get<T>(key);
+  if (cached !== undefined) {
+    return { data: cached, cached: true };
+  }
+
+  const data = await fetchFn();
+
+  if (data !== null && data !== undefined) {
+    cache.set(key, data, ttl);
+  }
+
+  return { data, cached: false };
+}
+
+export function cacheInvalidate(key: string): boolean {
+  return cache.del(key) > 0;
+}
+
+export function cacheStats() {
+  return cache.getStats();
+}

--- a/api/src/routes/quality.routes.ts
+++ b/api/src/routes/quality.routes.ts
@@ -1,49 +1,50 @@
 import { Router, Request, Response } from 'express';
 import { pool } from '../db';
+import { cacheGet } from '../cache';
 
 const router = Router();
 
 // Optimized quality distribution endpoint using single aggregated query
 // Performance improvements:
+// - In-memory caching (1 hour TTL) for repeated requests
 // - Single GROUP BY query replaces N+1 pattern (21 queries → 1 query)
 // - Database performs aggregation instead of API layer
 // - Static query (no user input) - no parameterization needed
-// Note: Still performing CAST on quality_score (stored as TEXT) - indexes will further optimize this
-router.get('/distribution', async (req: Request, res: Response) => {
+router.get('/distribution', async (_req: Request, res: Response) => {
   const startTime = Date.now();
 
   try {
-    // Single aggregated query with GROUP BY
-    // Uses conditional aggregation (SUM with CASE) for quality thresholds
-    const query = `
-      SELECT
-        study_id,
-        study_name,
-        COUNT(*) as total_measurements,
-        AVG(CAST(quality_score AS DECIMAL)) as avg_quality_score,
-        SUM(CASE WHEN CAST(quality_score AS DECIMAL) >= 0.9 THEN 1 ELSE 0 END) as high_quality_count,
-        SUM(CASE WHEN CAST(quality_score AS DECIMAL) < 0.8 THEN 1 ELSE 0 END) as low_quality_count
-      FROM clinical_data_raw
-      GROUP BY study_id, study_name
-      ORDER BY study_id
-    `;
+    const { data, cached } = await cacheGet('quality:distribution', async () => {
+      const query = `
+        SELECT
+          study_id,
+          study_name,
+          COUNT(*) as total_measurements,
+          AVG(CAST(quality_score AS DECIMAL)) as avg_quality_score,
+          SUM(CASE WHEN CAST(quality_score AS DECIMAL) >= 0.9 THEN 1 ELSE 0 END) as high_quality_count,
+          SUM(CASE WHEN CAST(quality_score AS DECIMAL) < 0.8 THEN 1 ELSE 0 END) as low_quality_count
+        FROM clinical_data_raw
+        GROUP BY study_id, study_name
+        ORDER BY study_id
+      `;
 
-    const result = await pool.query(query);
+      const result = await pool.query(query);
 
-    // Transform database results to match API response format
-    const data = result.rows.map(row => ({
-      study_id: row.study_id,
-      study_name: row.study_name,
-      total_measurements: parseInt(row.total_measurements),
-      avg_quality_score: parseFloat(row.avg_quality_score),
-      high_quality_count: parseInt(row.high_quality_count),
-      low_quality_count: parseInt(row.low_quality_count)
-    }));
+      return result.rows.map(row => ({
+        study_id: row.study_id,
+        study_name: row.study_name,
+        total_measurements: parseInt(row.total_measurements),
+        avg_quality_score: parseFloat(row.avg_quality_score),
+        high_quality_count: parseInt(row.high_quality_count),
+        low_quality_count: parseInt(row.low_quality_count)
+      }));
+    });
 
     const executionTime = Date.now() - startTime;
 
     res.json({
       data,
+      cached,
       executionTime: `${executionTime}ms`,
       executionTimeSeconds: (executionTime / 1000).toFixed(2)
     });

--- a/api/src/routes/studies.routes.ts
+++ b/api/src/routes/studies.routes.ts
@@ -1,49 +1,50 @@
 import { Router, Request, Response } from 'express';
 import { pool } from '../db';
+import { cacheGet } from '../cache';
 
 const router = Router();
 
 // Optimized study overview endpoint using single aggregated query
 // Performance improvements:
+// - In-memory caching (1 hour TTL) for repeated requests
 // - Single GROUP BY query replaces N+1 pattern (16 queries → 1 query)
 // - Database performs aggregation instead of API layer
 // - Uses COUNT(DISTINCT ...) for participant and site counts
-// - Static query (no user input) - no parameterization needed
-router.get('/overview', async (req: Request, res: Response) => {
+router.get('/overview', async (_req: Request, res: Response) => {
   const startTime = Date.now();
 
   try {
-    // Single aggregated query with GROUP BY
-    // Uses COUNT(DISTINCT ...) for unique counts of participants and sites
-    const query = `
-      SELECT
-        study_id,
-        study_name,
-        study_phase,
-        COUNT(DISTINCT participant_id) as participant_count,
-        COUNT(*) as total_measurements,
-        COUNT(DISTINCT site_id) as site_count
-      FROM clinical_data_raw
-      GROUP BY study_id, study_name, study_phase
-      ORDER BY study_id
-    `;
+    const { data, cached } = await cacheGet('studies:overview', async () => {
+      const query = `
+        SELECT
+          study_id,
+          study_name,
+          study_phase,
+          COUNT(DISTINCT participant_id) as participant_count,
+          COUNT(*) as total_measurements,
+          COUNT(DISTINCT site_id) as site_count
+        FROM clinical_data_raw
+        GROUP BY study_id, study_name, study_phase
+        ORDER BY study_id
+      `;
 
-    const result = await pool.query(query);
+      const result = await pool.query(query);
 
-    // Transform database results to match API response format
-    const data = result.rows.map(row => ({
-      study_id: row.study_id,
-      study_name: row.study_name,
-      study_phase: row.study_phase,
-      participant_count: parseInt(row.participant_count),
-      total_measurements: parseInt(row.total_measurements),
-      site_count: parseInt(row.site_count)
-    }));
+      return result.rows.map(row => ({
+        study_id: row.study_id,
+        study_name: row.study_name,
+        study_phase: row.study_phase,
+        participant_count: parseInt(row.participant_count),
+        total_measurements: parseInt(row.total_measurements),
+        site_count: parseInt(row.site_count)
+      }));
+    });
 
     const executionTime = Date.now() - startTime;
 
     res.json({
       data,
+      cached,
       executionTime: `${executionTime}ms`,
       executionTimeSeconds: (executionTime / 1000).toFixed(2)
     });
@@ -57,76 +58,72 @@ router.get('/overview', async (req: Request, res: Response) => {
 });
 
 // Get individual study participant summary by ID
+// In-memory caching with dynamic key per study
 router.get('/:studyId', async (req: Request, res: Response) => {
   const startTime = Date.now();
   const { studyId } = req.params;
 
   try {
-    // Aggregated query for participant summary
-    // Calculate age from DOB using EXTRACT(YEAR FROM AGE(...))
-    // Parameterized query ($1) prevents SQL injection
-    const query = `
-      SELECT
-        study_id,
-        study_name,
-        study_phase,
-        COUNT(DISTINCT participant_id) as total_participants,
-        AVG(EXTRACT(YEAR FROM AGE(CAST(participant_dob AS DATE)))) as avg_age,
-        MIN(EXTRACT(YEAR FROM AGE(CAST(participant_dob AS DATE)))) as min_age,
-        MAX(EXTRACT(YEAR FROM AGE(CAST(participant_dob AS DATE)))) as max_age,
-        COUNT(*) as total_measurements,
-        COUNT(DISTINCT site_id) as site_count,
-        MIN(CAST(measurement_timestamp AS DATE)) as start_date,
-        MAX(CAST(measurement_timestamp AS DATE)) as end_date
-      FROM clinical_data_raw
-      WHERE study_id = $1
-      GROUP BY study_id, study_name, study_phase
-    `;
+    const { data, cached } = await cacheGet(`studies:${studyId}`, async () => {
+      // Aggregated query for participant summary
+      // Calculate age from DOB using EXTRACT(YEAR FROM AGE(...))
+      // Parameterized query ($1) prevents SQL injection
+      const query = `
+        SELECT
+          study_id,
+          study_name,
+          study_phase,
+          COUNT(DISTINCT participant_id) as total_participants,
+          AVG(EXTRACT(YEAR FROM AGE(CAST(participant_dob AS DATE)))) as avg_age,
+          MIN(EXTRACT(YEAR FROM AGE(CAST(participant_dob AS DATE)))) as min_age,
+          MAX(EXTRACT(YEAR FROM AGE(CAST(participant_dob AS DATE)))) as max_age,
+          COUNT(*) as total_measurements,
+          COUNT(DISTINCT site_id) as site_count,
+          MIN(CAST(measurement_timestamp AS DATE)) as start_date,
+          MAX(CAST(measurement_timestamp AS DATE)) as end_date
+        FROM clinical_data_raw
+        WHERE study_id = $1
+        GROUP BY study_id, study_name, study_phase
+      `;
 
-    const result = await pool.query(query, [studyId]);
+      const result = await pool.query(query, [studyId]);
 
-    if (result.rows.length === 0) {
-      return res.status(404).json({
-        error: 'Study not found',
-        message: `No study found with ID: ${studyId}`
-      });
-    }
+      if (result.rows.length === 0) {
+        return null; // Don't cache 404s
+      }
 
-    // Get gender breakdown (parameterized query with $1)
-    const genderQuery = `
-      SELECT 
-        participant_gender,
-        COUNT(DISTINCT participant_id) as count
-      FROM clinical_data_raw
-      WHERE study_id = $1
-      GROUP BY participant_gender
-      ORDER BY participant_gender
-    `;
+      // Get gender breakdown (parameterized query with $1)
+      const genderQuery = `
+        SELECT
+          participant_gender,
+          COUNT(DISTINCT participant_id) as count
+        FROM clinical_data_raw
+        WHERE study_id = $1
+        GROUP BY participant_gender
+        ORDER BY participant_gender
+      `;
 
-    const genderResult = await pool.query(genderQuery, [studyId]);
+      const genderResult = await pool.query(genderQuery, [studyId]);
 
-    // Get site distribution with names (parameterized query with $1)
-    const siteQuery = `
-      SELECT 
-        site_id,
-        site_name,
-        COUNT(DISTINCT participant_id) as participant_count
-      FROM clinical_data_raw
-      WHERE study_id = $1
-      GROUP BY site_id, site_name
-      ORDER BY site_id
-    `;
+      // Get site distribution with names (parameterized query with $1)
+      const siteQuery = `
+        SELECT
+          site_id,
+          site_name,
+          COUNT(DISTINCT participant_id) as participant_count
+        FROM clinical_data_raw
+        WHERE study_id = $1
+        GROUP BY site_id, site_name
+        ORDER BY site_id
+      `;
 
-    const siteResult = await pool.query(siteQuery, [studyId]);
+      const siteResult = await pool.query(siteQuery, [studyId]);
 
-    const row = result.rows[0];
-    const totalParticipants = parseInt(row.total_participants);
-    const totalMeasurements = parseInt(row.total_measurements);
+      const row = result.rows[0];
+      const totalParticipants = parseInt(row.total_participants);
+      const totalMeasurements = parseInt(row.total_measurements);
 
-    const executionTime = Date.now() - startTime;
-
-    res.json({
-      data: {
+      return {
         study_id: row.study_id,
         study_name: row.study_name,
         study_phase: row.study_phase,
@@ -152,7 +149,21 @@ router.get('/:studyId', async (req: Request, res: Response) => {
           start_date: row.start_date,
           end_date: row.end_date
         }
-      },
+      };
+    });
+
+    if (data === null) {
+      return res.status(404).json({
+        error: 'Study not found',
+        message: `No study found with ID: ${studyId}`
+      });
+    }
+
+    const executionTime = Date.now() - startTime;
+
+    res.json({
+      data,
+      cached,
       executionTime: `${executionTime}ms`,
       executionTimeSeconds: (executionTime / 1000).toFixed(2)
     });

--- a/api/tests/api.integration.test.ts
+++ b/api/tests/api.integration.test.ts
@@ -11,6 +11,16 @@ jest.mock('../src/db', () => ({
   }
 }));
 
+// Mock the cache module - pass through to fetch function
+jest.mock('../src/cache', () => ({
+  cacheGet: jest.fn(async (_key: string, fetchFn: () => Promise<unknown>) => {
+    const data = await fetchFn();
+    return { data, cached: false };
+  }),
+  cacheInvalidate: jest.fn(),
+  cacheStats: jest.fn(() => ({ hits: 0, misses: 0 }))
+}));
+
 const mockPoolQuery = pool.query as jest.Mock;
 
 describe('API Contract Tests', () => {

--- a/api/tests/cache.test.ts
+++ b/api/tests/cache.test.ts
@@ -1,0 +1,44 @@
+import { cache, cacheGet } from '../src/cache';
+
+describe('Cache', () => {
+  beforeEach(() => {
+    cache.flushAll();
+  });
+
+  it('should return cached: true on second request', async () => {
+    let fetchCount = 0;
+    const fetchFn = async () => {
+      fetchCount++;
+      return { value: 'test-data' };
+    };
+
+    const first = await cacheGet('test-key', fetchFn);
+    const second = await cacheGet('test-key', fetchFn);
+
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(true);
+    expect(fetchCount).toBe(1); // fetchFn only called once
+    expect(second.data).toEqual({ value: 'test-data' });
+  });
+
+  it('should respect TTL and expire cached data', async () => {
+    const shortTtl = 1; // 1 second
+    let fetchCount = 0;
+    const fetchFn = async () => {
+      fetchCount++;
+      return { value: `fetch-${fetchCount}` };
+    };
+
+    const first = await cacheGet('ttl-key', fetchFn, shortTtl);
+    expect(first.cached).toBe(false);
+    expect(first.data).toEqual({ value: 'fetch-1' });
+
+    // Wait for TTL to expire
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    const second = await cacheGet('ttl-key', fetchFn, shortTtl);
+    expect(second.cached).toBe(false); // Cache expired, fetched again
+    expect(second.data).toEqual({ value: 'fetch-2' });
+    expect(fetchCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds in-memory caching to reduce database load on frequently-accessed endpoints.

**Cached endpoints:**
- `GET /api/studies/overview` → key: `studies:overview`
- `GET /api/studies/:studyId` → key: `studies:{id}`a
- `GET /api/quality/distribution` → key: `quality:distribution`

**Strategy:**
- [Cache-aside pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/cache-aside) via `cacheGet()` helper
- 1 hour TTL (configurable via `CACHE_TTL_SECONDS` env var)
- 404s are not cached
- Responses include `cached: true/false` for observability

**Possible future  extensions:**
- Consider Redis if usage grows

## Test plan
- [x] Integration tests pass
- [x] Verify cached responses return `cached: true` on second request
- [x] Verify cache respects TTL
